### PR TITLE
fixed issue with the global flag on variables being assumed as true

### DIFF
--- a/docs/changelogs/changelog-v0.6.0.md
+++ b/docs/changelogs/changelog-v0.6.0.md
@@ -12,3 +12,4 @@
 * Global variables couldn't be declared
 * comparisons using subscripts were broken
 * length did not change on modification
+* `stsvars::glob` was considered to be true by some compilers, causing crash

--- a/example/example.sts
+++ b/example/example.sts
@@ -1,11 +1,8 @@
-x: "";
-
-func getlength {
-    printl x|length, x;
-}
-
 do{
-    x: "hi";
-    printl x|length;
-    getlength;
+    x: 3;
+    y: 10;
+    while x not y {
+        x+: 1;
+        printl x;
+    }
 }

--- a/src/include/variables.h
+++ b/src/include/variables.h
@@ -13,7 +13,7 @@ public:
 	std::vector<stsvars> vals;
 
 	int length;
-	bool glob;
+	bool glob = false;
 	string name;
 
 	void assignlist(sts *script, std::vector<stsvars> vars, int *line);

--- a/src/values/man.cc
+++ b/src/values/man.cc
@@ -19,7 +19,7 @@ bool isvar(std::vector<stsvars> * pvars, string query, int *num) {
     return isvar;
 }
 
-bool sts::valchange(std::vector<stsvars> * pvars, std::vector<stsclasstype> *classtypes, int * ln){ //changes the value of the stsvars list
+bool sts::valchange(std::vector<stsvars> * pvars, std::vector<stsclasstype> *classtypes, int *ln){ //changes the value of the stsvars list
     std::vector<stsvars> vars = *pvars;
     int y = *ln;
     std::vector<stsclasstype> ct = *classtypes;


### PR DESCRIPTION
the `glob` flag on the `stsvars` class was assumed to be true causing crashes on some systems when variables were being modified.