### PR TITLE
fixed issue where random range could not be set to a variable

### DIFF
--- a/example/example.sts
+++ b/example/example.sts
@@ -1,3 +1,4 @@
 do{
-    printl random;
+    x: 50;
+    printl randomrange => min: 0, max: x;
 }

--- a/src/include/stsrand.h
+++ b/src/include/stsrand.h
@@ -6,7 +6,7 @@
 
 #include "variables.h"
 
-int genrandomintfromrange(std::vector<string> prs, int *line);
+int genrandomintfromrange(sts *s, std::vector<stsvars> vars, int *line);
 bool randombool();
 
 #endif

--- a/src/values/getvals.cc
+++ b/src/values/getvals.cc
@@ -74,7 +74,7 @@ stsvars sts::getval(std::vector<stsvars> vars, int *line) {
 
     else if (prs[y] == "randomrange") {
         v.type = 'i';
-        v.val = std::to_string(genrandomintfromrange(prs, &y));
+        v.val = std::to_string(genrandomintfromrange(this, vars, &y));
         *line = y;
         return v;
     }

--- a/src/values/random.cc
+++ b/src/values/random.cc
@@ -1,25 +1,27 @@
 #include "../include/stormscript.h"
 
-int genrandomintfromrange(std::vector<string> prs, int *line) {
+int genrandomintfromrange(sts *s, std::vector<stsvars> vars, int *line) {
     long int ut = static_cast<long int> (time(0)); // cast unix epoch to long int
     int y = *line;
     int range[2]; // range will store the min and max values
+
+    std::vector<string> prs = s->prs;
 
     srand(ut); // seed rand() with unix epoch
 
     y+=2;
     
     if (prs[y] == "min:")
-        range[0] = std::stoi(prs[y+1]);
+        range[0] = std::stoi(s->getval(vars, new int(y+1)).val);
     else if (prs[y] == "max:")
-        range[1] = std::stoi(prs[y+1]);
+        range[1] = std::stoi(s->getval(vars, new int(y+1)).val);
     
     y+=2;
 
     if (prs[y] == "min:")
-        range[0] = std::stoi(prs[y+1]);
+        range[0] = std::stoi(s->getval(vars, new int(y+1)).val);
     else if (prs[y] == "max:")
-        range[1] = std::stoi(prs[y+1]);
+        range[1] = std::stoi(s->getval(vars, new int(y+1)).val);
 
     y++;
 
@@ -33,3 +35,4 @@ bool randombool() {
     srand(ut);
     return rand() % 2;
 }
+


### PR DESCRIPTION
in random.cc, I set the range values to
```cpp
std::stoi(s->getval(vars, new int(y+1)).val);
```
instead of
```cpp
std::stoi(prs[y+1]);
```
to allow range parameters to be set to variables

So a program like
```
do{
    x: 50;
    printl randomrange => min: 0, max: x;
}
```
is possible
