### PR TITLE
fixed issue with write not allowing variables

### DIFF
--- a/src/stream/files.cc
+++ b/src/stream/files.cc
@@ -29,6 +29,9 @@ void sts::writefile(int y, std::vector<stsvars> vars) {
     std::ofstream file;
     string name = getval(vars, new int(y)).val;
     file.open(name);
-    file.write(striplit(prs[y+1]).c_str(), striplit(prs[y+1]).size());
+
+    string contents = getval(vars, new int(y+1)).val;
+
+    file.write(contents.c_str(), contents.size());
     file.close();
 }


### PR DESCRIPTION
Write allowed variables for file names but not for contents