### PR TITLE
make in bash scripts always uses all cores

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,13 +2,12 @@
 
 ## Supported Versions
 
-Use this section to tell people about which versions of your project are
-currently being supported with security updates.
-
 | Version | Supported          |
 | ------- | ------------------ |
 | 1.0.x   | :white_check_mark: |
 | 0.x.0   | :x:                |
+
+Beta versions are always supported. Any version below 1.0.0 is out of date.
 
 ## Reporting a Vulnerability
 

--- a/build-scripts/install.sh
+++ b/build-scripts/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 cmake CMakeLists.txt -DCMAKE_CXX_COMPILER:STRING="g++"
-make
+make -j $(nproc)
 sudo cp stormscript /usr/bin
 sudo cp src/core/errors.sts /usr/share/stormscript
 

--- a/build-scripts/installmac.sh
+++ b/build-scripts/installmac.sh
@@ -1,6 +1,6 @@
 brew install cmake
 cmake .
-make
+make -j $(nproc)
 cp src/core/errors.sts .
 touch ~/.profile
 echo "export PATH="`pwd`":\$PATH" >> ~/.profile

--- a/docs/changelogs/changelog-v1.0.0.md
+++ b/docs/changelogs/changelog-v1.0.0.md
@@ -1,4 +1,4 @@
-# StormScript 1.0.0
+# StormScript v1.0.0
 
 ## What's New
 * Use the `$` symbol followed by a variable name inside of a string literal to concatenate that variable into the string
@@ -18,6 +18,7 @@
 * Comparisons always work out to booleans, meaning that they are now interchangeable
 * Random no longer generates integers outside of range
 * Scoped variable inheritance now works, so variables defined inside of a scope are accessible to the scope and any child scopes
+* Install script now uses all available processor cores
 
 # Beta 1
 

--- a/scripts/packagerelease.sh
+++ b/scripts/packagerelease.sh
@@ -7,7 +7,7 @@ read vnum
 echo "Packaging stormscript v$vnum for release."
 
 cmake CMakeLists.txt -DCMAKE_CXX_COMPILER:STRING="g++"
-make
+make -j $(nproc)
 install stormscript build/stormscript
 rm stormscript
 

--- a/scripts/runtests.sh
+++ b/scripts/runtests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd ..
 cmake CMakeLists.txt
-make $1
+make -j $(nproc)
 install stormscript build/stormscript
 rm stormscript
 printf "\n \n \n"

--- a/scripts/writenewouts.sh
+++ b/scripts/writenewouts.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 cd ..
 cmake CMakeLists.txt
-make
+make -j $(nproc)
 install stormscript build/stormscript
 rm stormscript
 

--- a/src/core/stormscript.cc
+++ b/src/core/stormscript.cc
@@ -12,7 +12,7 @@
 */
 
 void printVersion() {
-	cout << "StormScript 1.0.0 Beta 1\n";
+	cout << "StormScript 1.0.0 Beta 2\n";
 }
 
 void showhelp() {


### PR DESCRIPTION
used
```sh
make -j $(nproc)
```
rather than
```
make
```
in build scripts to increase speed